### PR TITLE
Add type hints

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,10 @@ unreleased
 - Use GitHub Actions for CI.
   [jugmac00]
 
-- Switch to PEP-420 namespace package
+- Switch to PEP-420 namespace package.
+  [Daverball]
+
+- Add type hints.
   [Daverball]
 
 0.2.0 (2018-02-02)

--- a/more/content_security/core.py
+++ b/more/content_security/core.py
@@ -1,21 +1,43 @@
+from __future__ import annotations
+
 import base64
 import os
+from typing import TYPE_CHECKING, Literal
 
 from morepath import App
 from morepath.request import Request
 from more.content_security.policy import ContentSecurityPolicy
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import TypeVar
+
+    from webob import Response as BaseResponse
+
+    from morepath.types import Tween
+
+    _AppT = TypeVar(
+        "_AppT",
+        bound="ContentSecurityApp",
+        default="ContentSecurityApp",
+        covariant=True,
+    )
+else:
+    from typing import TypeVar
+
+    _AppT = TypeVar("_AppT", bound="ContentSecurityApp", covariant=True)
+
 # see https://csp.withgoogle.com/docs/faq.html#generating-nonces
 NONCE_LENGTH = 16
 
 
-def random_nonce():
+def random_nonce() -> str:
     return base64.b64encode(os.urandom(NONCE_LENGTH)).decode("utf-8")
 
 
-class ContentSecurityRequest(Request):
+class ContentSecurityRequest(Request[_AppT]):
     @property
-    def content_security_policy(self):
+    def content_security_policy(self) -> ContentSecurityPolicy:
         """Provides access to a request-local version of the content
         security policy.
 
@@ -29,13 +51,13 @@ class ContentSecurityRequest(Request):
                 self.app.settings.content_security_policy.default.copy()
             )
 
-        return self._content_security_policy
+        return self._content_security_policy  # type: ignore[no-any-return]
 
     @content_security_policy.setter
-    def content_security_policy(self, policy):
+    def content_security_policy(self, policy: ContentSecurityPolicy) -> None:
         self._content_security_policy = policy
 
-    def content_security_policy_nonce(self, target):
+    def content_security_policy_nonce(self, target: Literal["script", "style"]) -> str:
         """Generates a nonce that's random once per request, adds it to
         either 'style-src' or 'script-src' and returns its value.
 
@@ -57,7 +79,7 @@ class ContentSecurityRequest(Request):
         return nonce
 
     @property
-    def content_security_policy_nonce_value(self):
+    def content_security_policy_nonce_value(self) -> str:
         """Returns the request-bound content security nonce. It is secure
         to keep this once per request. It is only dangerous to use nonces
         over more than one request.
@@ -78,23 +100,29 @@ class ContentSecurityApp(App):
 
 
 @ContentSecurityApp.setting("content_security_policy", "default")
-def default_policy():
+def default_policy() -> ContentSecurityPolicy:
     return ContentSecurityPolicy()
 
 
 @ContentSecurityApp.setting("content_security_policy", "apply_policy")
-def default_policy_apply_factory():
-    def apply_policy(policy, request, response):
+def default_policy_apply_factory() -> (
+    Callable[[ContentSecurityPolicy, Request, BaseResponse], None]
+):
+    def apply_policy(
+        policy: ContentSecurityPolicy, request: Request, response: BaseResponse
+    ) -> None:
         policy.apply(response)
 
     return apply_policy
 
 
 @ContentSecurityApp.tween_factory()
-def content_security_policy_tween_factory(app, handler):
+def content_security_policy_tween_factory(
+    app: ContentSecurityApp, handler: Tween
+) -> Tween:
     policy_settings = app.settings.content_security_policy
 
-    def content_security_policy_tween(request):
+    def content_security_policy_tween(request: ContentSecurityRequest) -> BaseResponse:
         response = handler(request)
 
         if hasattr(request, "_content_security_policy"):

--- a/more/content_security/policy.py
+++ b/more/content_security/policy.py
@@ -1,6 +1,17 @@
+from __future__ import annotations
+
 import inspect
 
 from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Generic, TypeGuard, TypeVar, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+    from typing_extensions import Self
+
+    from webob.response import Response as BaseResponse
+
+_T = TypeVar("_T")
 
 SELF = "'self'"
 UNSAFE_INLINE = "'unsafe-inline'"
@@ -9,7 +20,7 @@ NONE = "'none'"
 STRICT_DYNAMIC = "'strict-dynamic'"
 
 
-class Directive:
+class Directive(Generic[_T]):
     """Descriptor for the management and rendering of CSP directives.
 
     Uses types to do some basic sanity checking. This does not ensure
@@ -20,13 +31,19 @@ class Directive:
 
     """
 
-    def __init__(self, name, type, default, render):
+    def __init__(
+        self,
+        name: str,
+        type: type[_T],
+        default: Callable[[], _T],
+        render: Callable[[_T], str | None],
+    ) -> None:
         self.name = name
         self.type = type
         self.default = default
         self.renderer = render
 
-    def render(self, instance):
+    def render(self, instance: ContentSecurityPolicy) -> str | None:
         if self.name not in instance.__dict__:
             return None
 
@@ -35,49 +52,55 @@ class Directive:
 
         return self.renderer(instance.__dict__[self.name])
 
-    def __get__(self, instance, cls):
+    @overload
+    def __get__(self, instance: None, cls: type[ContentSecurityPolicy]) -> Self: ...
+    @overload
+    def __get__(
+        self, instance: ContentSecurityPolicy, cls: type[ContentSecurityPolicy]
+    ) -> _T: ...
+
+    def __get__(
+        self, instance: ContentSecurityPolicy | None, cls: type[ContentSecurityPolicy]
+    ) -> _T | Self:
         if instance is None:
             return self
 
         if self.name not in instance.__dict__:
             instance.__dict__[self.name] = self.default()
 
-        return instance.__dict__[self.name]
+        return instance.__dict__[self.name]  # type: ignore[no-any-return]
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: ContentSecurityPolicy, value: _T) -> None:
         if not isinstance(value, self.type):
             raise TypeError(f"Expected type {self.type}")
 
         instance.__dict__[self.name] = value
 
 
-class SetDirective(Directive):
-    def __init__(self, name):
-        parent = super()
-        parent.__init__(name, type=set, default=set, render=render_set)
+class SetDirective(Directive[set[str]]):
+    def __init__(self, name: str) -> None:
+        super().__init__(name, type=set, default=set, render=render_set)
 
 
-class SingleValueDirective(Directive):
-    def __init__(self, name):
-        parent = super()
-        parent.__init__(name, type=str, default=str, render=str)
+class SingleValueDirective(Directive[str]):
+    def __init__(self, name: str) -> None:
+        super().__init__(name, type=str, default=str, render=str)
 
 
-class BooleanDirective(Directive):
-    def __init__(self, name):
-        parent = super()
-        parent.__init__(name, type=bool, default=bool, render=render_bool)
+class BooleanDirective(Directive[bool]):
+    def __init__(self, name: str) -> None:
+        super().__init__(name, type=bool, default=bool, render=render_bool)
 
 
-def is_directive(obj):
+def is_directive(obj: object) -> TypeGuard[Directive[Any]]:
     return isinstance(obj, Directive)
 
 
-def render_set(value):
+def render_set(value: set[str]) -> str:
     return " ".join(sorted(value))
 
 
-def render_bool(value):
+def render_bool(value: bool) -> str | None:
     return "" if value else None
 
 
@@ -103,39 +126,52 @@ class ContentSecurityPolicy:
     """
 
     # Fetch directives
-    child_src = SetDirective("child-src")
-    connect_src = SetDirective("connect-src")
-    default_src = SetDirective("default-src")
-    font_src = SetDirective("font-src")
-    frame_src = SetDirective("frame-src")
-    img_src = SetDirective("img-src")
-    manifest_src = SetDirective("manifest-src")
-    media_src = SetDirective("media-src")
-    object_src = SetDirective("object-src")
-    script_src = SetDirective("script-src")
-    style_src = SetDirective("style-src")
-    worker_src = SetDirective("worker-src")
+    child_src: SetDirective = SetDirective("child-src")
+    connect_src: SetDirective = SetDirective("connect-src")
+    default_src: SetDirective = SetDirective("default-src")
+    font_src: SetDirective = SetDirective("font-src")
+    frame_src: SetDirective = SetDirective("frame-src")
+    img_src: SetDirective = SetDirective("img-src")
+    manifest_src: SetDirective = SetDirective("manifest-src")
+    media_src: SetDirective = SetDirective("media-src")
+    object_src: SetDirective = SetDirective("object-src")
+    script_src: SetDirective = SetDirective("script-src")
+    style_src: SetDirective = SetDirective("style-src")
+    worker_src: SetDirective = SetDirective("worker-src")
 
     # Document directives
-    base_uri = SetDirective("base-uri")
-    plugin_types = SetDirective("plugin-types")
-    sandbox = SingleValueDirective("sandbox")
-    disown_opener = BooleanDirective("disown-opener")
+    base_uri: SetDirective = SetDirective("base-uri")
+    plugin_types: SetDirective = SetDirective("plugin-types")
+    sandbox: SingleValueDirective = SingleValueDirective("sandbox")
+    disown_opener: BooleanDirective = BooleanDirective("disown-opener")
 
     # Navigation directives
-    form_action = SetDirective("form-action")
-    frame_ancestors = SetDirective("frame-ancestors")
+    form_action: SetDirective = SetDirective("form-action")
+    frame_ancestors: SetDirective = SetDirective("frame-ancestors")
 
     # Reporting directives
-    report_uri = SingleValueDirective("report-uri")
-    report_to = SingleValueDirective("report-to")
+    report_uri: SingleValueDirective = SingleValueDirective("report-uri")
+    report_to: SingleValueDirective = SingleValueDirective("report-to")
 
     # Other directives
-    block_all_mixed_content = BooleanDirective("block-all-mixed-content")
-    require_sri_for = SingleValueDirective("require-sri-for")
-    upgrade_insecure_requeists = BooleanDirective("upgrade-insecure-requests")
+    block_all_mixed_content: BooleanDirective = BooleanDirective(
+        "block-all-mixed-content"
+    )
+    require_sri_for: SingleValueDirective = SingleValueDirective("require-sri-for")
+    upgrade_insecure_requeists: BooleanDirective = BooleanDirective(
+        "upgrade-insecure-requests"
+    )
 
-    def __init__(self, report_only=False, **directives):
+    def __init__(
+        self,
+        report_only: bool = False,
+        # NOTE: This is both a little too lax and a little too strict, but
+        #       it doesn't seem worth defining a TypedDict, to get better
+        #       type checking on this, this will work for most cases and
+        #       is not the recommended style of defining the directives
+        #       anyways.
+        **directives: set[str] | str | bool,
+    ) -> None:
         self.report_only = report_only
 
         for directive in directives:
@@ -144,32 +180,35 @@ class ContentSecurityPolicy:
             assert hasattr(self, name)
             setattr(self, name, directives[directive])
 
-    def copy(self):
+    def copy(self) -> Self:
         policy = self.__class__()
         policy.__dict__ = deepcopy(self.__dict__)
 
         return policy
 
     @property
-    def directives(self):
+    def directives(self) -> Generator[Directive[Any]]:
         for name, value in inspect.getmembers(self.__class__, is_directive):
             yield value
 
     @property
-    def text(self):
-        values = ((d.name, d.render(self)) for d in self.directives)
-        values = ((name, text) for name, text in values if text is not None)
+    def text(self) -> str:
+        values = (
+            (d.name, text)
+            for d in self.directives
+            if (text := d.render(self)) is not None
+        )
 
         return ";".join(" ".join(v).strip() for v in values)
 
     @property
-    def header_name(self):
+    def header_name(self) -> str:
         if self.report_only:
             return "Content-Security-Policy-Report-Only"
         else:
             return "Content-Security-Policy"
 
-    def apply(self, response):
+    def apply(self, response: BaseResponse) -> None:
         text = self.text
 
         if text:

--- a/more/content_security/tests/test_app.py
+++ b/more/content_security/tests/test_app.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
 
 from more.content_security import ContentSecurityApp
 from more.content_security import ContentSecurityPolicy
 from more.content_security import SELF
 from webtest import TestApp as Client
 
+if TYPE_CHECKING:
+    from more.content_security.core import ContentSecurityRequest
 
-def test_content_security_default_remains_untouched():
+
+def test_content_security_default_remains_untouched() -> None:
     class App(ContentSecurityApp):
         pass
 
@@ -15,11 +21,11 @@ def test_content_security_default_remains_untouched():
         pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: ContentSecurityRequest) -> str:
         return "view"
 
     @App.view(model=Model, name="protected")
-    def protected(self, request):
+    def protected(self: Model, request: ContentSecurityRequest) -> str:
         request.content_security_policy.default_src.add(SELF)
         return "protected"
 
@@ -35,7 +41,7 @@ def test_content_security_default_remains_untouched():
     assert "Content-Security-Policy" not in response.headers
 
 
-def test_content_security_defaults_may_be_extended():
+def test_content_security_defaults_may_be_extended() -> None:
     class App(ContentSecurityApp):
         pass
 
@@ -44,16 +50,16 @@ def test_content_security_defaults_may_be_extended():
         pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: ContentSecurityRequest) -> str:
         return "view"
 
     @App.view(model=Model, name="extended")
-    def protected(self, request):
+    def protected(self: Model, request: ContentSecurityRequest) -> str:
         request.content_security_policy.default_src.add("https://example.org")
         return "extended"
 
     @App.setting("content_security_policy", "default")
-    def default_policy():
+    def default_policy() -> ContentSecurityPolicy:
         return ContentSecurityPolicy(default_src={SELF})
 
     client = Client(App())
@@ -67,7 +73,7 @@ def test_content_security_defaults_may_be_extended():
     )
 
 
-def test_content_security_nonce():
+def test_content_security_nonce() -> None:
     class App(ContentSecurityApp):
         pass
 
@@ -76,7 +82,7 @@ def test_content_security_nonce():
         pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: ContentSecurityRequest) -> str:
         return '<style nonce="{}"><style><script nonce="{}"></script>'.format(
             request.content_security_policy_nonce("style"),
             request.content_security_policy_nonce("script"),
@@ -90,7 +96,9 @@ def test_content_security_nonce():
     assert "style-src 'nonce-" in text
     assert "script-src 'nonce-" in text
 
-    nonce = re.search(r"nonce-([^\']+)", text).group(1)
+    match = re.search(r"nonce-([^\']+)", text)
+    assert match is not None
+    nonce = match.group(1)
 
     # nonces are per-request, not per nonce call
     assert f'style nonce="{nonce}"' in response.text
@@ -104,10 +112,12 @@ def test_content_security_nonce():
     assert "script-src 'nonce-" in text
 
     assert nonce not in text
-    assert nonce != re.search(r"nonce-([^\']+)", text).group(1)
+    match = re.search(r"nonce-([^\']+)", text)
+    assert match is not None
+    assert nonce != match.group(1)
 
 
-def test_content_security_report_only():
+def test_content_security_report_only() -> None:
     class App(ContentSecurityApp):
         pass
 
@@ -116,11 +126,11 @@ def test_content_security_report_only():
         pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: ContentSecurityRequest) -> str:
         return "view"
 
     @App.setting("content_security_policy", "default")
-    def default_policy():
+    def default_policy() -> ContentSecurityPolicy:
         return ContentSecurityPolicy(report_only=True, default_src={SELF})
 
     client = Client(App())

--- a/more/content_security/tests/test_policy.py
+++ b/more/content_security/tests/test_policy.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 import pytest
 
 from more.content_security import ContentSecurityPolicy
 
 
-def test_policy_initialisation():
+def test_policy_initialisation() -> None:
     policy = ContentSecurityPolicy(default_src={"https://example.org"})
     assert policy.text == "default-src https://example.org"
 
-    policy = ContentSecurityPolicy(**{"default-src": {"https://example.org"}})
+    policy = ContentSecurityPolicy(
+        report_only=False, **{"default-src": {"https://example.org"}}
+    )
     assert policy.text == "default-src https://example.org"
 
 
-def test_multivalue_directive():
+def test_multivalue_directive() -> None:
     policy = ContentSecurityPolicy()
     assert policy.text == ""
 
@@ -28,10 +32,10 @@ def test_multivalue_directive():
     assert policy.text == ""
 
     with pytest.raises(TypeError):
-        policy.default_src = []
+        policy.default_src = []  # type: ignore
 
 
-def test_singevalue_directive():
+def test_singevalue_directive() -> None:
     policy = ContentSecurityPolicy()
 
     policy.sandbox = "allow-forms"
@@ -41,10 +45,10 @@ def test_singevalue_directive():
     assert policy.text == ""
 
     with pytest.raises(TypeError):
-        policy.sandbox = None
+        policy.sandbox = None  # type: ignore
 
 
-def test_boolean_directive():
+def test_boolean_directive() -> None:
     policy = ContentSecurityPolicy()
 
     policy.block_all_mixed_content = True
@@ -54,10 +58,10 @@ def test_boolean_directive():
     assert policy.text == ""
 
     with pytest.raises(TypeError):
-        policy.block_all_mixed_content = None
+        policy.block_all_mixed_content = None  # type: ignore
 
 
-def test_multiple_directives():
+def test_multiple_directives() -> None:
     policy = ContentSecurityPolicy()
 
     policy.default_src.add("https://example.org")
@@ -72,7 +76,7 @@ def test_multiple_directives():
     )
 
 
-def test_copy_directive():
+def test_copy_directive() -> None:
     policy = ContentSecurityPolicy()
     assert policy.text == ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 requires-python = ">= 3.10"
+# TODO: pin to morepath >= 1
 dependencies = ["morepath"]
 
 [project.urls]
@@ -34,9 +35,14 @@ Changelog = "https://github.com/morepath/more.content_security/blob/master/HISTO
 test = ["pytest >= 8", "pytest-env", "WebTest"]
 coverage = ["pytest-cov"]
 lint = ["black", "flake8", "flake8-pyproject"]
+mypy = ["mypy", "pytest", "types-WebOb", "types-WebTest"]
+pyright = ["pyright", "pytest", "types-WebOb", "types-WebTest", "WebTest"]
 
 [tool.setuptools.packages]
 find = {}
+
+[tool.setuptools.package-data]
+"more.content_security" = ["py.typed"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "HISTORY.rst"]}
@@ -56,8 +62,13 @@ show_missing = true
 
 [tool.flake8]
 show-source = true
-ignore = ["E203", "E231", "W503"]
+ignore = ["E203", "E231", "E301", "E704", "W503"]
 max-line-length = 88
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unreachable = true
 
 [tool.bumpversion]
 current_version = "0.2.0"
@@ -81,10 +92,10 @@ unreleased
 ~~~~~~~~~~)?
 """
 replace = """
----------
+---------(?:
 
-{new_version} ({now:%d.%m.%Y})
-~~~~~~~~~~~~~~~~~~~
+(?:unreleased|[0-9]+\\.[0-9]+\\.[0-9]+(:?\\.[a-z]+[0-9]*)? \\(unreleased\\))
+~+)
 """
 
 [tool.tox]
@@ -98,12 +109,14 @@ env_list = [
     "pypy3",
     "coverage",
     "pre-commit",
+    "mypy",
+    "pyright",
 ]
 skip_missing_interpreters = true
 
 [tool.tox.gh.python]
 "3.10" = ["py310"]
-"3.11" = ["py311"]
+"3.11" = ["py311", "mypy", "pyright"]
 "3.12" = ["py312"]
 "3.13" = ["py313"]
 "3.14" = ["py314", "pre-commit", "coverage"]
@@ -112,6 +125,7 @@ skip_missing_interpreters = true
 [tool.tox.env_run_base]
 package = "editable"
 extras = ["test"]
+deps = ["-r{tox_root}/requirements/corelibs.txt"]
 commands = [["pytest", "{posargs:more}"]]
 
 [tool.tox.env.coverage]
@@ -127,4 +141,26 @@ package = "skip"
 deps = ["pre-commit"]
 commands = [
     ["pre-commit", "run", "--all-files"],
+]
+
+[tool.tox.env.mypy]
+base_python = ["python3"]
+extras = ["mypy"]
+commands = [
+    ["mypy", "-p", "more.content_security", "--python-version", "3.10"],
+    ["mypy", "-p", "more.content_security", "--python-version", "3.11"],
+    ["mypy", "-p", "more.content_security", "--python-version", "3.12"],
+    ["mypy", "-p", "more.content_security", "--python-version", "3.13"],
+    ["mypy", "-p", "more.content_security", "--python-version", "3.14"],
+]
+
+[tool.tox.env.pyright]
+base_python = ["python3"]
+extras = ["pyright"]
+commands = [
+    ["pyright", "more/content_security", "--pythonversion", "3.10"],
+    ["pyright", "more/content_security", "--pythonversion", "3.11"],
+    ["pyright", "more/content_security", "--pythonversion", "3.12"],
+    ["pyright", "more/content_security", "--pythonversion", "3.13"],
+    ["pyright", "more/content_security", "--pythonversion", "3.14"],
 ]

--- a/requirements/corelibs.txt
+++ b/requirements/corelibs.txt
@@ -1,0 +1,5 @@
+# Points to the master branches of Morepath, Reg and Dectate on Github
+git+https://github.com/morepath/reg.git@master#egg=reg
+git+https://github.com/morepath/dectate.git@master#egg=dectate
+git+https://github.com/morepath/importscan.git@master#egg=importscan
+git+https://github.com/morepath/morepath.git@master#egg=morepath

--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -1,3 +1,6 @@
+# sources
+-r corelibs.txt
+
 # development
 -e '.[test,coverage,lint]'
 pre-commit


### PR DESCRIPTION
The only slightly controversial type hint is for `**directives` in `ContentSecurityPolicy.__init__`, since it could both be more permissive (for subclasses) and less permissive (for catching misspelled directives), but seeing as the general style is to first create an empty policy and then set the directives one at a time, I think the current trade-off between type safety and ergonomics is fine.

/cc @henri-hulski 